### PR TITLE
Improve locale section of the docs

### DIFF
--- a/docs/color/RGB.md
+++ b/docs/color/RGB.md
@@ -1,7 +1,7 @@
 # RGB
 ### `LaravelExtendedValidation\Rules\Color\RGB`
 
-This validation rules checks if the posted input is a valid RGB color code. The color values should be between 0 and 255.  
+This validation rules checks if the posted input is a valid RGB color code. The color values should be between `0` and `255`.
 
 The validator does not care about casing of the 'RGB' section.
 

--- a/docs/color/RGBA.md
+++ b/docs/color/RGBA.md
@@ -1,13 +1,14 @@
 # RGBA
 ### `LaravelExtendedValidation\Rules\Color\RGBA`
 
-This validation rules checks if the posted input is a valid RGB color code. The color values should be between 0 and 255.
+This validation rules checks if the posted input is a valid RGB color code. The color values should be between `0` and `255`.
+and the alpha channel should be between `0.1` and `1.0`.
 
-The validator does not care about casing of the 'RGB' section.
+The validator does not care about casing of the 'RGBA' section.
 
 ```
-- rgba(255,255,255)
-- RGBA(255,255,255)
+- rgba(255,255,255,0.1)
+- RGBA(255,255,255,0.5)
 ```
 
 ## Constructor argument(s)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,22 +63,22 @@ nav:
       - dateandtime/TimeZoneAbbr.md
       - dateandtime/UnixTime.md
   - 'Locales':
-      - 'BE':
+      - 'Belgium (BE)':
           - locale/BE/Address/PostalCode.md
           - locale/BE/Company/VatNumber.md
-      - 'DE':
+      - 'Germany (DE)':
           - locale/DE/Company/VatNumber.md
           - locale/DE/Address/PostalCode.md
-      - 'FR':
+      - 'France (FR)':
           - locale/FR/Company/VatNumber.md
           - locale/FR/Address/PostalCode.md
-      - 'LU':
+      - 'Luxemburg (LU)':
           - locale/LU/Company/VatNumber.md
-      - 'NL':
+      - 'Netherlands, The (NL)':
           - locale/NL/Address/PostalCode.md
           - locale/NL/Person/SocialSecurityNumber.md
           - locale/NL/Company/VatNumber.md
-      - 'UK':
+      - 'United Kingdom (UK)':
           - locale/UK/Address/PostalCode.md
   - 'Network':
       - network/IPv4.md


### PR DESCRIPTION
Closes #75 

The doc site will now show the full country name instead of only the ISO 3166-2 country code. 

![image](https://user-images.githubusercontent.com/17492906/149589892-840fc6ea-4855-40e9-b00d-0f53619d9ad5.png)
