### PR TITLE
 Fixed domain extension length

### DIFF
--- a/src/Rules/Network/Domain.php
+++ b/src/Rules/Network/Domain.php
@@ -14,7 +14,7 @@ class Domain implements Rule
     {
         $domain = Str::of($value);
 
-        return $domain->match('/^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,6}$/')->length() !== 0;
+        return $domain->match('/^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,}$/')->length() !== 0;
     }
 
     /**

--- a/tests/Network/DomainTest.php
+++ b/tests/Network/DomainTest.php
@@ -15,6 +15,7 @@ test('that we can successfully validate domains', function ($domain, $expectedOu
     ['something.co.uk', true],
     ['xn--c6h.com', true], // ♡.com
     ['g.co', true],
+    ['foo.accountants', true],
     ['notld', false],
     ['test.t.t.c', false],
     ['-domain.tld', false],


### PR DESCRIPTION
Fixed issue where domain extension can only be between 2 and 6 chars long

Relates to #125 